### PR TITLE
Fix: "Unable to retrieve the file_size" on file upload (Filament 5 / Livewire)

### DIFF
--- a/src/Adapters/StorageAdapter.php
+++ b/src/Adapters/StorageAdapter.php
@@ -463,13 +463,16 @@ class StorageAdapter implements FileManagerAdapterInterface
         }
 
         try {
+            $fileSize = $file->getSize();
+            $fileMimeType = $file->getMimeType();
+            
             $storedPath = $file->storeAs($fullPath ?: '', $originalName, $this->disk);
 
             Log::info('FileManager file uploaded', [
                 'path' => $storedPath,
-                'original_name' => $file->getClientOriginalName(),
-                'size' => $file->getSize(),
-                'mime_type' => $file->getMimeType(),
+                'original_name' => $originalName,
+                'size' => $fileSize,
+                'mime_type' => $fileMimeType,
                 'disk' => $this->disk,
                 'user_id' => auth()->id(),
             ]);


### PR DESCRIPTION
**Description**
This PR fixes an issue where successful file uploads are logged and treated as errors, throwing `Unable to retrieve the file_size for file at location: livewire-tmp/...`. 

**Root Cause**
With recent Livewire versions (especially noticeable after upgrading to Filament 5), temporary files are moved/deleted immediately upon calling `$file->storeAs()`. 
Because the `Log::info` block directly after `storeAs()` tried to fetch `$file->getSize()` and `$file->getMimeType()` from the temporary `livewire-tmp` path, Flysystem threw a `UnableToRetrieveMetadata` exception.

**Solution**
I simply reordered the logic to retrieve the file metadata (`size` and `mime_type`) *before* `storeAs()` is executed. This prevents the exception and allows the upload flow to complete successfully.
